### PR TITLE
Add canvas renderer with viewport control

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,22 @@
 import './style.css'
-import typescriptLogo from './typescript.svg'
-import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.ts'
+import { Map } from './map'
+import { Renderer } from './renderer'
 
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://www.typescriptlang.org/" target="_blank">
-      <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
-    </a>
-    <h1>Vite + TypeScript</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
-    </div>
-    <p class="read-the-docs">
-      Click on the Vite and TypeScript logos to learn more
-    </p>
-  </div>
-`
+const app = document.querySelector<HTMLDivElement>('#app')!
+const canvas = document.createElement('canvas')
+canvas.width = 800
+canvas.height = 600
+app.innerHTML = ''
+app.appendChild(canvas)
 
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+const ctx = canvas.getContext('2d')!
+const map = new Map(50, 50)
+const renderer = new Renderer(map, ctx)
+renderer.attachListeners(canvas)
+
+function loop(): void {
+  renderer.render()
+  requestAnimationFrame(loop)
+}
+
+loop()

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,0 +1,22 @@
+export class Map {
+  readonly width: number
+  readonly height: number
+  private readonly tiles: number[][]
+
+  constructor(width: number, height: number) {
+    this.width = width
+    this.height = height
+    this.tiles = []
+    for (let y = 0; y < height; y++) {
+      const row: number[] = []
+      for (let x = 0; x < width; x++) {
+        row.push(Math.random() < 0.2 ? 1 : 0)
+      }
+      this.tiles.push(row)
+    }
+  }
+
+  get(x: number, y: number): number {
+    return this.tiles[y]?.[x] ?? 0
+  }
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,0 +1,83 @@
+import { Map } from './map'
+
+interface Viewport {
+  x: number
+  y: number
+  scale: number
+}
+
+export class Renderer {
+  private readonly map: Map
+  private readonly ctx: CanvasRenderingContext2D
+  private readonly tileSize: number
+  private viewport: Viewport
+  private readonly speed = 20
+
+  constructor(map: Map, ctx: CanvasRenderingContext2D, tileSize = 32) {
+    this.map = map
+    this.ctx = ctx
+    this.tileSize = tileSize
+    this.viewport = { x: 0, y: 0, scale: 1 }
+  }
+
+  attachListeners(canvas: HTMLCanvasElement): void {
+    window.addEventListener('keydown', this.onKeyDown)
+    canvas.addEventListener('wheel', this.onWheel, { passive: false })
+  }
+
+  private onKeyDown = (e: KeyboardEvent): void => {
+    switch (e.key.toLowerCase()) {
+      case 'w':
+        this.viewport.y -= this.speed
+        break
+      case 's':
+        this.viewport.y += this.speed
+        break
+      case 'a':
+        this.viewport.x -= this.speed
+        break
+      case 'd':
+        this.viewport.x += this.speed
+        break
+      default:
+        return
+    }
+    this.clamp()
+  }
+
+  private onWheel = (e: WheelEvent): void => {
+    e.preventDefault()
+    const zoom = e.deltaY > 0 ? 0.9 : 1.1
+    const { offsetX, offsetY } = e
+    const worldX = (offsetX + this.viewport.x) / this.viewport.scale
+    const worldY = (offsetY + this.viewport.y) / this.viewport.scale
+    this.viewport.scale = Math.min(4, Math.max(0.5, this.viewport.scale * zoom))
+    this.viewport.x = worldX * this.viewport.scale - offsetX
+    this.viewport.y = worldY * this.viewport.scale - offsetY
+    this.clamp()
+  }
+
+  private clamp(): void {
+    const maxX = this.map.width * this.tileSize * this.viewport.scale - this.ctx.canvas.width
+    const maxY = this.map.height * this.tileSize * this.viewport.scale - this.ctx.canvas.height
+    this.viewport.x = Math.min(Math.max(this.viewport.x, 0), Math.max(0, maxX))
+    this.viewport.y = Math.min(Math.max(this.viewport.y, 0), Math.max(0, maxY))
+  }
+
+  render(): void {
+    const { ctx } = this
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+    ctx.save()
+    ctx.scale(this.viewport.scale, this.viewport.scale)
+    ctx.translate(-this.viewport.x / this.viewport.scale, -this.viewport.y / this.viewport.scale)
+
+    for (let y = 0; y < this.map.height; y++) {
+      for (let x = 0; x < this.map.width; x++) {
+        ctx.fillStyle = this.map.get(x, y) === 1 ? '#444' : '#ddd'
+        ctx.fillRect(x * this.tileSize, y * this.tileSize, this.tileSize, this.tileSize)
+      }
+    }
+
+    ctx.restore()
+  }
+}


### PR DESCRIPTION
## Summary
- create simple Map representation
- implement Renderer with zoom and panning controls
- update entrypoint to draw map on a canvas

## Testing
- `npm run build` *(fails: Cannot find module './style.css')*

------
https://chatgpt.com/codex/tasks/task_e_6840c57cb848832d88d6b0e913f15e0c