### PR TITLE
Fix TypeScript asset imports

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+declare module '*.svg' {
+  const src: string
+  export default src
+}
+
+declare module '*.css'
+


### PR DESCRIPTION
## Summary
- fix TypeScript build errors with custom declarations for `.svg` and `.css` files

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c0e01c88832d886accaaa400c48f